### PR TITLE
Initialize feature to save history

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,17 +2,36 @@ import io from 'socket.io'
 let port = process.env.PORT || 3000
 const server = io.listen(port)
 
+let history = [];
+
 server.on('connection', (socket) => {
   console.log('user connected')
   socket.emit('welcome', 'welcome man')
 
+  if(history.length != 0){
+    socket.emit('history', history)
+  }
+
   socket.on('draw', (data) => {
     console.log("Received 'draw' event at (" + data.x + ', ' + data.y + ') from client IP ' + socket.handshake.address)
+    history.push(data)
     socket.broadcast.emit('draw', data)
   })
 
   socket.on('erase-all', () => {
     console.log('erase all')
+    history = [];
     socket.broadcast.emit('erase-all')
+  })
+
+  socket.on('undo', () => {
+    console.log('undo event')
+    let draw = history.pop()
+    socket.broadcast('undo', draw)
+  })
+
+  socket.on('recalibrate', () => {
+    console.log('recalibrate from client IP ' + socket.handshake.address)
+    socket.broadcast('history', history)
   })
 })

--- a/frontend/src/components/Canvas/DrawingCanvas.js
+++ b/frontend/src/components/Canvas/DrawingCanvas.js
@@ -7,6 +7,7 @@ import squarePng from '../../images/Square.png'
 import eraserPng from '../../images/Eraser.png'
 
 let socket
+let history = []
 
 if (window.location.href.includes('localhost') || window.location.href.includes('127.0.0.1')) {
   socket = io.connect('127.0.0.1:3000')
@@ -72,6 +73,49 @@ export default function canvas (p) {
           p.rect(data.x - (data.size / 2), data.y - (data.size / 2), data.size, data.size)
         } else if (data.tool === 'eraser') {
           p.ellipse(data.x, data.y, data.size, data.size)
+        }
+
+        history.push(draw)
+      }
+    )
+
+    socket.on('history', 
+      function (data) {
+        for(let i = 0; i < data.length; i++){
+          p.noStroke()
+          p.fill(data[i].color)
+
+          if (data[i].tool === 'circle') {
+            p.ellipse(data[i].x, data[i].y, data[i].size, data[i].size)
+          } else if (data[i].tool === 'square') {
+            p.rect(data[i].x - (data[i].size / 2), data[i].y - (data[i].size / 2), data[i].size, data[i].size)
+          } else if (data[i].tool === 'eraser') {
+            p.ellipse(data[i].x, data[i].y, data[i].size, data[i].size)
+          }
+        }
+        history = draw
+      }
+    )
+
+    socket.on('undo', 
+      function (data) {
+        let last = history.pop()
+        if(last.x == data.x && last.y == data.y){
+          p.background(255)
+          for (let i = 0; i < history.length; i++) {
+            p.noStroke()
+            p.fill(data.color)
+
+            if (data[i].tool === 'circle') {
+              p.ellipse(data[i].x, data[i].y, data[i].size, data[i].size)
+            } else if (data[i].tool === 'square') {
+              p.rect(data[i].x - (data[i].size / 2), data[i].y - (data[i].size / 2), data[i].size, data[i].size)
+            } else if (data[i].tool === 'eraser') {
+              p.ellipse(data[i].x, data[i].y, data[i].size, data[i].size)
+            }
+          }
+        }else{
+          socket.emit('recalibrate')
         }
       }
     )

--- a/frontend/src/components/Canvas/DrawingCanvas.js
+++ b/frontend/src/components/Canvas/DrawingCanvas.js
@@ -122,6 +122,7 @@ export default function canvas (p) {
 
     socket.on('erase-all', () => {
       p.background(255)
+      history = []
     })
   }
 


### PR DESCRIPTION
This PR aims to implement one of the "Gang of Four Book" design principals.

Primarily, this will initialize the history feature on the server side and the client side.
Clients should be able to undo and redo.

Future things to consider to make this more efficient could be saving canvas states client side, and also probably sending events in batches.