### PR TITLE
Fixing being able to start game multiple times

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -19,6 +19,7 @@ server.on('connection', (socket) => {
       socket.join(roomData.roomId)
       const gameSession = new Game(server, roomId)
       rooms[roomId] = new Room(roomId, socket.id, server, name, gameSession)
+      gameSession.assignRoom(rooms[roomId])
       playersRooms[socket.id] = rooms[roomId]
       socket.emit('confirm-valid-room-code')
     } else {

--- a/backend/src/game.js
+++ b/backend/src/game.js
@@ -2,30 +2,53 @@ export default class Game {
   constructor (server, roomId) {
     this.server = server
     this.roomId = roomId
+    this.room = null
     this.timeRemaining = 60 // How much time is remaining in the current round
     this.roundsRemaining = 2 // How many rounds are left until the game is over
     this.isGameOver = false // Checks if the game is over or not
+    this.timer = null
+    this.started = false
+    this.currentDrawer = null
   }
 
   startGame () {
-    const timer = setInterval(() => {
-      if (this.timeRemaining > 0) { // If there is still time on the clock, reduce it
-        this.timeRemaining -= 1
-      } else { // Round is over
-        if (this.roundsRemaining === 0) { // Game is over
-          clearInterval(timer) // Stop the timer
-          this.isGameOver = true
-        } else { // Switch to a new round
-          this.timeRemaining = 60 // Reset the clock for the next round
-          this.roundsRemaining -= 1
+    if(!this.started || this.isGameOver){
+      this.started = true
+      this.isGameOver = false
+      this.timer = setInterval(() => {
+        if (this.timeRemaining > 0) { // If there is still time on the clock, reduce it
+          this.timeRemaining -= 1
+        } else { // Round is over
+          if (this.roundsRemaining === 0) { // Game is over
+            clearInterval(this.timer) // Stop the timer
+            this.isGameOver = true
+            this.room.systemChat("Game is now over!")
+          } else { // Switch to a new round
+            this.timeRemaining = 60 // Reset the clock for the next round
+            this.roundsRemaining -= 1
+            this.room.systemChat("Time has expired for this round, next round starting!")
+          }
         }
-      }
-      this.server.in(this.roomId).emit('timer-update', this.timeRemaining)
-    }, 1000)
+        this.server.in(this.roomId).emit('timer-update', this.timeRemaining)
+      }, 1000)
+    } else {
+      this.room.systemChat("The game has already started!")
+    }
   }
 
-  // Gives each player in the room 2 turns
+  // Once the room is created to host this game session, the game session should be aware
+  // of the room's existence too
+  assignRoom (room) {
+    this.room = room
+  }
+
+  // Gives each player 3 turns of drawing if less than 4 players
+  // Or 2 drawing turns each when 4 players or more
   calculateTotalRounds (numberOfPlayers) {
-    return numberOfPlayers * 2
+    if(numberOfPlayers < 4){
+      return numberOfPlayers * 3
+    } else {
+      return numberOfPlayers * 2
+    }
   }
 }

--- a/backend/src/game.js
+++ b/backend/src/game.js
@@ -62,9 +62,9 @@ export default class Game {
         await sleep(60000)
         this.shouldScorePoints = false
         if(turnQueue.length > 1){
-          this.room.systemChat("Turn is over! There are " + turnQueue.length + " more turns!")
+          this.room.systemChat(`Round over! The word was ${this.gameState.currentWord}! There are ${turnQueue.length} more rounds!`)
         }else if(turnQueue.length == 1){
-          this.room.systemChat("Turn is over! There is " + turnQueue.length + " more turn!")
+          this.room.systemChat(`Round over! The word was ${this.gameState.currentWord}! There is ${turnQueue.length} more round!`)
         }
         await sleep(5000)
         this.pointsForTheRound = {}

--- a/backend/src/game.js
+++ b/backend/src/game.js
@@ -40,7 +40,7 @@ export default class Game {
   async startGame () {
     if (!this.gameState.isGameStarted) {
       this.gameState.isGameStarted = true
-      const turnQueue = [...this.gameState.players, ...this.gameState.players]
+      const turnQueue = getRandomizedQueue()
       let wordbank = wordBank()
 
       while (turnQueue.length > 0) {
@@ -61,11 +61,16 @@ export default class Game {
         this.startTimer(60)
         await sleep(60000)
         this.shouldScorePoints = false
+        if(turnQueue.length > 1){
+          this.room.systemChat("Turn is over! There are " + turnQueue.length + " more turns!")
+        }else if(turnQueue.length == 1){
+          this.room.systemChat("Turn is over! There is " + turnQueue.length + " more turn!")
+        }
         await sleep(5000)
         this.pointsForTheRound = {}
       }
-
       this.gameState.isGameOver = true
+      this.room.systemChat("Game is over, thanks for playing!")
     } else {
       this.room.systemChat("A game is already underway!")
     }
@@ -107,19 +112,13 @@ export default class Game {
     }, 1000)
   }
 
-  // Once the room is created to host this game session, the game session should be aware
-  // of the room's existence too
-  assignRoom (room) {
-    this.room = room
-  }
-
   // Gives each player 3 turns of drawing if less than 4 players
   // Or 2 drawing turns each when 4 players or more
-  calculateTotalRounds (numberOfPlayers) {
-    if(numberOfPlayers < 4){
-      return numberOfPlayers * 3
+  getRandomizedQueue () {
+    if(this.gameState.players.length < 4){
+      return [...this.gameState.players, ...this.gameState.players, ...this.gameState.players]
     } else {
-      return numberOfPlayers * 2
+      return [...this.gameState.players, ...this.gameState.players]
     }
   }
 }

--- a/backend/src/room.js
+++ b/backend/src/room.js
@@ -18,6 +18,14 @@ export default class Room {
     this.server.in(this.roomId).emit('chat-update', this.chatMessages)
   }
 
+  systemChat (systemMessage) {
+    this.chatMessages.push({
+      name: "System",
+      message: systemMessage
+    })
+    this.server.in(this.roomId).emit('chat-update', this.chatMessages)
+  }
+
   getChatHistory () {
     this.server.in(this.roomId).emit('chat-update', this.chatMessages)
   }

--- a/backend/src/room.js
+++ b/backend/src/room.js
@@ -21,7 +21,8 @@ export default class Room {
   systemChat (systemMessage) {
     this.chatMessages.push({
       name: "System",
-      message: systemMessage
+      message: systemMessage,
+      isSystem: true
     })
     this.server.in(this.roomId).emit('chat-update', this.chatMessages)
   }

--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -24,11 +24,19 @@ class Chat extends React.Component {
 
   renderChatMessages () {
     const messages = this.state.chatMessages.map((message, index) => {
-      return (
-        <p key={index}>
-          {message.name}: {message.message}
-        </p>
-      )
+      if("isSystem" in message && message.isSystem == true){
+        return (
+          <p key={index} style="color:red">
+            {message.name}: {message.message}
+          </p>
+        )
+      }else{
+        return (
+          <p key={index}>
+            {message.name}: {message.message}
+          </p>
+        )
+      }
     })
 
     return <div className='messages'>


### PR DESCRIPTION
This PR adds a started indicator, which when combined with the isGameOver indicator, should prevent players from starting the game multiple times.

Sidenote: this also adds a rudimentary system chat feature which is the primary way for the server to communicate with the client.